### PR TITLE
Add Celery beat scheduler and daily recap email task

### DIFF
--- a/packages/backend/scripts/celery/run_celery_beat.py
+++ b/packages/backend/scripts/celery/run_celery_beat.py
@@ -1,0 +1,18 @@
+"""
+Run the Celery beat scheduler
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+# Import and run the Celery beat scheduler
+from src.side_quest_py.celery_app import celery_app
+
+if __name__ == "__main__":
+    argv = [
+        "beat",
+        "--loglevel=INFO",
+    ]
+    celery_app.worker_main(argv)

--- a/packages/backend/src/side_quest_py/celery_app.py
+++ b/packages/backend/src/side_quest_py/celery_app.py
@@ -1,11 +1,13 @@
+"""
+Celery app for Side Quest
+"""
+
 from celery import Celery
+from celery.schedules import crontab
 from src.side_quest_py.api.config import settings
 
 # Create Celery instance
-celery_app = Celery(
-    "side_quest",
-    broker=settings.CELERY_BROKER_URL,
-)
+celery_app = Celery("side_quest", broker=settings.CELERY_BROKER_URL, include=["src.side_quest_py.tasks.email_tasks"])
 
 # Configure Celery
 celery_app.conf.update(
@@ -15,3 +17,11 @@ celery_app.conf.update(
     timezone="UTC",
     enable_utc=True,
 )
+
+celery_app.conf.beat_schedule = {
+    "send-daily-recap-emails": {
+        "task": "src.side_quest_py.tasks.email_tasks.send_daily_recap_emails",
+        # Run daily at 1:00 AM UTC
+        "schedule": crontab(hour=1, minute=0),
+    },
+}

--- a/packages/backend/src/side_quest_py/tasks/email_tasks.py
+++ b/packages/backend/src/side_quest_py/tasks/email_tasks.py
@@ -1,17 +1,18 @@
-import smtplib
+from datetime import datetime, timedelta
+from collections import defaultdict
+
+# import smtplib
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 
 from src.side_quest_py.celery_app import celery_app
 from src.side_quest_py.database import SessionLocal
-from src.side_quest_py.models.db_models import User, Adventurer
+from src.side_quest_py.models.db_models import User, Adventurer, Quest, QuestCompletion
 from src.side_quest_py.api.config import settings
 
 
 class EmailSendError(Exception):
     """Exception raised when an email fails to send."""
-
-    pass
 
 
 @celery_app.task
@@ -73,6 +74,144 @@ def send_level_up_email(adventurer_id: str, old_level: int, new_level: int):
         db.close()
 
 
+@celery_app.task
+def send_daily_recap_emails():
+    """
+    Generate and send daily recap emails to all users.
+    This task should be scheduled to run once per day.
+    """
+    db = SessionLocal()
+    try:
+        # Calculate yesterday's date range
+        today = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        yesterday_start = today - timedelta(days=1)
+        yesterday_end = today
+
+        # Get all quest completions from yesterday with related data
+        completions = (
+            db.query(QuestCompletion, Quest, Adventurer)
+            .join(Quest, QuestCompletion.quest_id == Quest.id)
+            .join(Adventurer, QuestCompletion.adventurer_id == Adventurer.id)
+            .filter(QuestCompletion.created_at >= yesterday_start, QuestCompletion.created_at < yesterday_end)
+            .all()
+        )
+
+        # Group completions by user
+        user_completions = defaultdict(lambda: defaultdict(list))
+
+        for completion, quest, adventurer in completions:
+            user_id = adventurer.user_id
+            user_completions[user_id][adventurer.id].append((quest, completion))
+
+        # Send recap email to each user who had activity
+        for user_id, adventurer_completions in user_completions.items():
+            # Get user info
+            user = db.query(User).filter(User.id == user_id).first()
+            if not user:
+                continue
+
+            # Generate and send the email
+            send_user_daily_recap(user, adventurer_completions, yesterday_start.date())
+
+        return f"Daily recap emails sent to {len(user_completions)} users"
+    finally:
+        db.close()
+
+
+def send_user_daily_recap(user, adventurer_completions, recap_date):
+    """
+    Send a daily recap email to a specific user.
+
+    Args:
+        user: User object with email and username
+        adventurer_completions: Dict mapping adventurer_id to list of (quest, completion) tuples
+        recap_date: The date of the activity being recapped
+    """
+    db = SessionLocal()
+    try:
+        # Get adventurer details
+        adventurer_ids = list(adventurer_completions.keys())
+        adventurers = {adv.id: adv for adv in db.query(Adventurer).filter(Adventurer.id.in_(adventurer_ids)).all()}
+
+        # Format date for email
+        formatted_date = recap_date.strftime("%A, %B %d, %Y")
+
+        # Calculate overall stats
+        total_quests = sum(len(quests) for quests in adventurer_completions.values())
+        total_xp = sum(
+            quest.experience_reward for adv_quests in adventurer_completions.values() for quest, _ in adv_quests
+        )
+
+        # Create email subject and intro
+        subject = f"Your Side Quest Daily Recap for {formatted_date}"
+
+        # Start building HTML content
+        html_content = f"""
+        <html>
+        <body style="font-family: Arial, sans-serif; line-height: 1.6;">
+            <h1 style="color: #4b6584;">Daily Quest Recap</h1>
+            <p>Hello {user.username},</p>
+            <p>Here's your daily adventure summary for <strong>{formatted_date}</strong>:</p>
+            
+            <div style="background-color: #f7f7f7; padding: 10px; border-radius: 5px; margin: 15px 0;">
+                <h3 style="margin-top: 0; color: #3867d6;">Overall Progress</h3>
+                <p>Total Quests Completed: <strong>{total_quests}</strong></p>
+                <p>Total Experience Gained: <strong>{total_xp} XP</strong></p>
+            </div>
+        """
+
+        # Add details for each adventurer
+        for adventurer_id, quests_info in adventurer_completions.items():
+            adventurer = adventurers.get(adventurer_id)
+            if not adventurer:
+                continue
+
+            # Calculate adventurer-specific stats
+            adv_xp = sum(quest.experience_reward for quest, _ in quests_info)
+
+            html_content += f"""
+            <div style="margin-bottom: 20px; border-left: 4px solid #3867d6; padding-left: 15px;">
+                <h2 style="color: #3867d6; margin-bottom: 10px;">{adventurer.name} (Level {adventurer.level})</h2>
+                <p>Quests Completed: <strong>{len(quests_info)}</strong></p>
+                <p>Experience Gained: <strong>{adv_xp} XP</strong></p>
+                
+                <ul style="list-style-type: none; padding-left: 0;">
+            """
+
+            # List each quest completed by this adventurer
+            for quest, completion in quests_info:
+                # Format completion time
+                completion_time = completion.created_at.strftime("%I:%M %p")
+
+                html_content += f"""
+                <li style="padding: 8px; margin-bottom: 8px; background-color: #f1f2f6; border-radius: 4px;">
+                    <div style="font-weight: bold;">{quest.title}</div>
+                    <div style="color: #576574; font-size: 0.9em;">Completed at {completion_time}</div>
+                    <div style="color: #20bf6b; font-size: 0.9em;">+{quest.experience_reward} XP</div>
+                </li>
+                """
+
+            html_content += """
+                </ul>
+            </div>
+            """
+
+        # Add footer
+        html_content += """
+            <p>Keep up the great adventuring!</p>
+            <p>The Side Quest Team</p>
+        </body>
+        </html>
+        """
+
+        # Send the email
+        send_email(user.email, subject, html_content)
+
+        return f"Daily recap email sent to {user.email}"
+    finally:
+        db.close()
+
+
 def send_email(to_email: str, subject: str, html_body: str):
     """Helper function to send an email.
 
@@ -85,10 +224,10 @@ def send_email(to_email: str, subject: str, html_body: str):
         str: Message indicating the email was sent successfully
     """
     # Email configuration
-    smtp_server = settings.SMTP_SERVER
-    smtp_port = settings.SMTP_PORT
-    smtp_username = settings.SMTP_USERNAME
-    smtp_password = settings.SMTP_PASSWORD
+    # smtp_server = settings.SMTP_SERVER
+    # smtp_port = settings.SMTP_PORT
+    # smtp_username = settings.SMTP_USERNAME
+    # smtp_password = settings.SMTP_PASSWORD
     from_email = settings.SMTP_SENDER_EMAIL
 
     # Create message


### PR DESCRIPTION
- Introduced a new script to run the Celery beat scheduler.
- Updated the Celery app configuration to include a scheduled task for sending daily recap emails.
- Implemented the `send_daily_recap_emails` task to generate and send recap emails to users based on their quest completions from the previous day.
- Enhanced the email formatting and content to provide a comprehensive summary of user activity.

#59 